### PR TITLE
Release 0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wristband-fastapi-auth"
-version = "0.3.0"
+version = "0.4.0"
 description = "SDK for integrating your Python FastAPI application with Wristband. Handles user authentication and token management."
 readme = "README_PYPI.md"
 license = "MIT"
@@ -13,7 +13,7 @@ authors = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "cryptography>=44.0.3,<45.0.0",
+    "cryptography>=44.0.3",
     "fastapi>=0.100.0",
     "httpx>=0.24.0",
 ]

--- a/src/wristband/fastapi_auth/__init__.py
+++ b/src/wristband/fastapi_auth/__init__.py
@@ -14,15 +14,15 @@ from .utils import SessionEncryptor
 
 # Explicitly define what's available for import
 __all__ = [
-    "WristbandAuth",
     "AuthConfig",
     "CallbackData",
     "CallbackResult",
     "CallbackResultType",
     "LoginConfig",
     "LogoutConfig",
+    "SessionEncryptor",
     "TokenData",
     "UserInfo",
+    "WristbandAuth",
     "WristbandError",
-    "SessionEncryptor",
 ]

--- a/src/wristband/fastapi_auth/models.py
+++ b/src/wristband/fastapi_auth/models.py
@@ -1,14 +1,14 @@
-from dataclasses import asdict, dataclass, field
 from enum import Enum
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, List, Optional
+
+from pydantic import BaseModel, Field
 
 ########################################
 # AUTH CONFIG MODELS
 ########################################
 
 
-@dataclass
-class AuthConfig:
+class AuthConfig(BaseModel):
     """
     Represents the configuration for Wristband authentication.
 
@@ -54,12 +54,11 @@ class AuthConfig:
     login_url: Optional[str] = None
     parse_tenant_from_root_domain: Optional[str] = None
     redirect_uri: Optional[str] = None
-    scopes: List[str] = field(default_factory=lambda: ["openid", "offline_access", "email"])
+    scopes: List[str] = Field(default=["openid", "offline_access", "email"])
     token_expiration_buffer: int = 60
 
 
-@dataclass
-class SdkConfiguration:
+class SdkConfiguration(BaseModel):
     """
     Represents the SDK configuration returned from Wristband's SDK Auto-Configuration Endpoint.
 
@@ -104,8 +103,7 @@ class SdkConfiguration:
 ########################################
 
 
-@dataclass
-class LoginConfig:
+class LoginConfig(BaseModel):
     """
     Represents the configuration for login.
 
@@ -127,8 +125,7 @@ class LoginConfig:
     return_url: Optional[str] = None
 
 
-@dataclass
-class OAuthAuthorizeUrlConfig:
+class OAuthAuthorizeUrlConfig(BaseModel):
     """
     Represents the configuration for building OAuth authorization URLs.
 
@@ -164,8 +161,7 @@ class OAuthAuthorizeUrlConfig:
     is_application_custom_domain_active: Optional[bool] = False
 
 
-@dataclass
-class LoginState:
+class LoginState(BaseModel):
     """
     Represents all possible state for the current login request, which is stored in the login state cookie.
 
@@ -182,15 +178,6 @@ class LoginState:
     redirect_uri: str
     return_url: Optional[str]
     custom_state: Optional[dict[str, Any]]
-
-    def to_dict(self) -> Dict[str, Union[str, Dict[str, str]]]:
-        """
-        Converts the LoginState instance to a dictionary representation.
-
-        Returns:
-            A dictionary containing all the login state data.
-        """
-        return asdict(self)
 
 
 ########################################
@@ -221,8 +208,7 @@ claims that can be returned, depending on your scopes.
 """
 
 
-@dataclass
-class CallbackData:
+class CallbackData(BaseModel):
     """
     Represents the callback data received after authentication.
 
@@ -250,18 +236,8 @@ class CallbackData:
     return_url: Optional[str]
     tenant_custom_domain: Optional[str]
 
-    def to_dict(self) -> dict[str, Any]:
-        """
-        Converts the CallbackData instance to a dictionary representation.
 
-        Returns:
-            A dictionary containing all the callback data.
-        """
-        return asdict(self)
-
-
-@dataclass
-class TokenData:
+class TokenData(BaseModel):
     """
     Represents the token data received after authentication.
 
@@ -280,8 +256,7 @@ class TokenData:
     refresh_token: str
 
 
-@dataclass
-class CallbackResult:
+class CallbackResult(BaseModel):
     """
     Represents the result of the callback execution after authentication. It can include the set of
     callback data necessary for creating an authenticated session in the event a redirect is not required.
@@ -297,8 +272,7 @@ class CallbackResult:
     redirect_url: Optional[str]
 
 
-@dataclass
-class TokenResponse:
+class TokenResponse(BaseModel):
     """
     Represents the token response received from the Wristband token endpoint.
 
@@ -344,8 +318,7 @@ class TokenResponse:
 ########################################
 
 
-@dataclass
-class LogoutConfig:
+class LogoutConfig(BaseModel):
     """
     Represents the configuration for logout.
 

--- a/tests/auth/test_refresh_token_if_expired.py
+++ b/tests/auth/test_refresh_token_if_expired.py
@@ -344,9 +344,13 @@ async def test_refresh_token_if_expired_other_exception_with_retries(wristband_a
 async def test_refresh_token_if_expired_timestamp_boundary(wristband_auth):
     """Test behavior at the exact expiration timestamp boundary."""
     # Set expires_at to exactly current time
-    current_timestamp = int(datetime.now().timestamp() * 1000)
-
-    result = await wristband_auth.refresh_token_if_expired("refresh_token", current_timestamp)
+    with patch("wristband.fastapi_auth.auth.datetime") as mock_datetime:
+        mock_now = Mock()
+        mock_now.timestamp.return_value = 1000000  # Fixed timestamp
+        mock_datetime.now.return_value = mock_now
+        
+        current_timestamp = int(1000000 * 1000)  # Same timestamp in milliseconds
+        result = await wristband_auth.refresh_token_if_expired("refresh_token", current_timestamp)
 
     # Should return None since token is not yet expired (>= check)
     assert result is None

--- a/tests/auth/test_refresh_token_if_expired.py
+++ b/tests/auth/test_refresh_token_if_expired.py
@@ -348,7 +348,7 @@ async def test_refresh_token_if_expired_timestamp_boundary(wristband_auth):
         mock_now = Mock()
         mock_now.timestamp.return_value = 1000000  # Fixed timestamp
         mock_datetime.now.return_value = mock_now
-        
+
         current_timestamp = int(1000000 * 1000)  # Same timestamp in milliseconds
         result = await wristband_auth.refresh_token_if_expired("refresh_token", current_timestamp)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,3 @@
-from dataclasses import asdict
-
 from wristband.fastapi_auth.models import (
     AuthConfig,
     CallbackData,
@@ -325,8 +323,8 @@ def test_login_state_creation():
     assert login_state.custom_state == custom_state
 
 
-def test_login_state_to_dict():
-    """Test LoginState to_dict method."""
+def test_login_state_model_dump():
+    """Test LoginState model_dump method."""
     custom_state = {"key": "value"}
     login_state = LoginState(
         state="test_state",
@@ -336,7 +334,7 @@ def test_login_state_to_dict():
         custom_state=custom_state,
     )
 
-    result = login_state.to_dict()
+    result = login_state.model_dump()
     expected = {
         "state": "test_state",
         "code_verifier": "test_verifier",
@@ -362,7 +360,7 @@ def test_login_state_with_none_values():
     assert login_state.return_url is None
     assert login_state.custom_state is None
 
-    result = login_state.to_dict()
+    result = login_state.model_dump()
     assert result["return_url"] is None
     assert result["custom_state"] is None
 
@@ -453,8 +451,8 @@ def test_callback_data_creation():
     assert callback_data.tenant_custom_domain == "tenant1.example.com"
 
 
-def test_callback_data_to_dict():
-    """Test CallbackData to_dict method."""
+def test_callback_data_model_dump():
+    """Test CallbackData model_dump method."""
     user_info = {"sub": "user123"}
     callback_data = CallbackData(
         access_token="access_token_123",
@@ -469,7 +467,7 @@ def test_callback_data_to_dict():
         tenant_custom_domain=None,
     )
 
-    result = callback_data.to_dict()
+    result = callback_data.model_dump()
 
     assert isinstance(result, dict)
     assert result["access_token"] == "access_token_123"
@@ -673,15 +671,15 @@ def test_logout_config_state_field():
 ########################################
 
 
-def test_dataclass_asdict_compatibility():
-    """Test that all dataclasses work with asdict function."""
+def test_pydantic_model_dump_compatibility():
+    """Test that all Pydantic models work with model_dump method."""
     # Test AuthConfig with minimal required fields
     auth_config = AuthConfig(
         client_id="test",
         client_secret="secret",
         wristband_application_vanity_domain="app.wristband.dev",
     )
-    auth_dict = asdict(auth_config)
+    auth_dict = auth_config.model_dump()
     assert isinstance(auth_dict, dict)
     assert auth_dict["client_id"] == "test"
 
@@ -693,7 +691,7 @@ def test_dataclass_asdict_compatibility():
         return_url=None,
         custom_state=None,
     )
-    login_dict = asdict(login_state)
+    login_dict = login_state.model_dump()
     assert isinstance(login_dict, dict)
     assert login_dict["state"] == "state"
 
@@ -710,7 +708,7 @@ def test_dataclass_asdict_compatibility():
         return_url=None,
         tenant_custom_domain=None,
     )
-    callback_dict = asdict(callback_data)
+    callback_dict = callback_data.model_dump()
     assert isinstance(callback_dict, dict)
     assert callback_dict["access_token"] == "token"
 
@@ -730,7 +728,7 @@ def test_nested_dict_handling():
         custom_state=complex_custom_state,
     )
 
-    result_dict = login_state.to_dict()
+    result_dict = login_state.model_dump()
     assert result_dict["custom_state"] == complex_custom_state
     assert result_dict["custom_state"]["user_preferences"]["theme"] == "dark"  # type: ignore
 


### PR DESCRIPTION
- When the `login()` method cannot resolve a tenant domain from the request (subdomain, query parameters, or defaults), the SDK redirects users to the Application-Level Login (Tenant Discovery) Page. To ensure a seamless user experience, any provided return URL values are automatically preserved by appending them to the `state` query parameter. This allows the return URL to be propagated back to the Login Endpoint once tenant discovery is complete, ensuring users land at their originally intended destination after authentication.

- The README has been updated to show the FastAPI Dependency approach to protecting APIs in favor of the prior Middleware-based approach.

- The README has been updated to show how to implement CSRF protection in FastAPI

- All model classes have been migrated from Python dataclasses to Pydantic models for improved validation and serialization.