### PR TITLE
Release 2.1.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     name: Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -866,6 +866,22 @@ GET https://customer01.yourapp.io/auth/login?login_hint=user@wristband.dev
 
 If Wristband passes this parameter, it will be appended as part of the redirect request to the Wristband Authorize Endpoint. Typically, the email form field on the Tenant-Level Login page is pre-filled when a user has previously entered their email on the Application-Level Login Page.
 
+#### IDP Hints
+
+If you want to bypass the Wristband-hosted Tenant Login Page entirely and send users directly to a specific identity provider's login page, you can pass the `idp_hint` query parameter to your Login Endpoint:
+
+```sh
+GET https://customer01.yourapp.io/auth/login?idp_hint=google
+```
+
+The value should be the `name` field of an identity provider that is currently enabled for the tenant. When Wristband receives this hint, it checks if the provided IdP name matches an enabled identity provider for that tenant:
+
+- **Matching external IdP (e.g. `google`)** — Wristband skips the Tenant Login Page entirely and redirects the user straight to that external IdP's login page (e.g. Google's login page).
+- **Wristband IdP name** — Wristband displays the Tenant Login Page but shows only the Wristband email-based login form, hiding any external IdP buttons.
+- **Unrecognized or invalid value** — Wristband ignores the hint and displays the Tenant Login Page as normal.
+
+This is useful when your application already knows which identity provider a user should authenticate with, allowing you to skip the IdP selection step entirely and provide a more seamless login experience.
+
 #### Return URLs
 
 It is possible that users will try to access a location within your application that is not some default landing page. In those cases, they would expect to immediately land back at that desired location after logging in.  This is a better experience for the user, especially in cases where they have application URLs bookmarked for convenience.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wristband-fastapi-auth"
-version = "2.0.1"
+version = "2.1.0"
 description = "SDK for integrating your Python FastAPI application with Wristband. Handles user authentication and token management."
 readme = "README_PYPI.md"
 license = "MIT"
@@ -13,10 +13,10 @@ authors = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "cryptography>=44.0.3",
+    "cryptography>=46.0.6",
     "fastapi>=0.100.0",
     "httpx>=0.24.0",
-    "wristband-python-jwt==0.1.1",
+    "wristband-python-jwt==0.1.2"
 ]
 keywords = [
     "api",
@@ -66,7 +66,8 @@ dev = [
     "bandit>=1.7.0",
     "build>=0.10.0",
     "twine>=4.0.0",
-    "black>=23.0.0",
+    "requests>=2.32.4",
+    "black>=26.3.1",
     "isort>=5.12.0",
 ]
 

--- a/src/wristband/fastapi_auth/auth.py
+++ b/src/wristband/fastapi_auth/auth.py
@@ -106,6 +106,8 @@ class WristbandAuth:
         Request to begin the Authorization Code flow.
 
         The incoming FastAPI request can include Wristband-specific query parameters:
+        - idp_hint: A hint to Wristband about which identity provider the user should be redirected to. When present,
+          Wristband will bypass the Tenant Login Page and send the user directly to the specified identity provider.
         - login_hint: A hint about the user's preferred login identifier. This is passed as a query
           parameter in the redirect to the Authorize URL.
         - return_url: The URL to redirect the user to after authentication.
@@ -884,6 +886,10 @@ class WristbandAuth:
         if len(login_hint_list) > 1:
             raise TypeError("More than one [login_hint] query parameter was encountered")
 
+        idp_hint_list = request.query_params.getlist("idp_hint")
+        if len(idp_hint_list) > 1:
+            raise TypeError("More than one [idp_hint] query parameter was encountered")
+
         # Assemble necessary query params for authorization request
         query_params: dict[str, str] = {
             "client_id": config.client_id,
@@ -897,6 +903,8 @@ class WristbandAuth:
         }
         if login_hint_list:
             query_params["login_hint"] = login_hint_list[0]
+        if idp_hint_list:
+            query_params["idp_hint"] = idp_hint_list[0]
 
         # Separator changes to a period if using an app-level custom domain with tenant subdomains
         separator: Literal[".", "-"] = "." if config.is_application_custom_domain_active else "-"

--- a/src/wristband/fastapi_auth/config_resolver.py
+++ b/src/wristband/fastapi_auth/config_resolver.py
@@ -176,13 +176,6 @@ class ConfigResolver:
 
     def _validate_all_dynamic_configs(self, sdk_configuration: SdkConfiguration) -> None:
         """Validate all dynamic configurations after SDK config is loaded."""
-        # Validate that required fields are present in the SDK config response
-        if not sdk_configuration.login_url:
-            raise WristbandError("sdk_config_invalid", "SDK configuration response missing required field: login_url")
-        if not sdk_configuration.redirect_uri:
-            raise WristbandError(
-                "sdk_config_invalid", "SDK configuration response missing required field: redirect_uri"
-            )
 
         # Use manual config values if provided, otherwise use SDK config values
         login_url = self.auth_config.login_url or sdk_configuration.login_url
@@ -190,6 +183,16 @@ class ConfigResolver:
         parse_tenant_from_root_domain = (
             self.auth_config.parse_tenant_from_root_domain or sdk_configuration.login_url_tenant_domain_suffix or ""
         )
+
+        # Validate that required fields are present in the SDK config response
+        if not login_url:
+            raise WristbandError("sdk_config_invalid", "SDK configuration response missing required field: login_url")
+        if not redirect_uri:
+            raise WristbandError(
+                "sdk_config_invalid",
+                "The [redirect_uri] could not be resolved. Provide it explicitly in your SDK config "
+                "or ensure your Wristband OAuth2 Client has a single redirect URI configured.",
+            )
 
         # Validate the tenant domain token logic with final resolved values
         if parse_tenant_from_root_domain:
@@ -324,7 +327,7 @@ class ConfigResolver:
         # 2. If auto-configure is enabled, get from SDK config
         if self.get_auto_configure_enabled():
             sdk_config = await self._load_sdk_config()
-            return sdk_config.redirect_uri
+            return sdk_config.redirect_uri or ""
 
         # 3. This should not happen if validation is done properly
         raise TypeError("The [redirect_uri] config must have a value")

--- a/src/wristband/fastapi_auth/models.py
+++ b/src/wristband/fastapi_auth/models.py
@@ -74,7 +74,7 @@ class SdkConfiguration(BaseModel):
     """
 
     login_url: str
-    redirect_uri: str
+    redirect_uri: Optional[str] = None
     is_application_custom_domain_active: bool
     custom_application_login_page_url: Optional[str] = None
     login_url_tenant_domain_suffix: Optional[str] = None
@@ -92,7 +92,7 @@ class SdkConfiguration(BaseModel):
         """
         return SdkConfiguration(
             login_url=response["loginUrl"],
-            redirect_uri=response["redirectUri"],
+            redirect_uri=response.get("redirectUri"),
             is_application_custom_domain_active=response.get("isApplicationCustomDomainActive", False),
             custom_application_login_page_url=response.get("customApplicationLoginPageUrl"),
             login_url_tenant_domain_suffix=response.get("loginUrlTenantDomainSuffix"),

--- a/tests/auth/test_login.py
+++ b/tests/auth/test_login.py
@@ -887,6 +887,44 @@ class TestWristbandAuthGetOAuthAuthorizeUrl:
         with pytest.raises(TypeError, match="More than one \\[login_hint\\] query parameter was encountered"):
             self.wristband_auth._get_oauth_authorize_url(mock_request, oauth_config)
 
+    def test_get_oauth_authorize_url_with_idp_hint(self) -> None:
+        """Test _get_oauth_authorize_url includes idp_hint when present."""
+
+        request = create_mock_request("/login", query_params={"idp_hint": "google"})
+        oauth_config = OAuthAuthorizeUrlConfig(
+            client_id=self.auth_config.client_id,
+            redirect_uri=self.auth_config.redirect_uri or "",
+            code_verifier="test_verifier",
+            scopes=self.auth_config.scopes,
+            state="test_state",
+            tenant_custom_domain="custom.tenant.com",
+            wristband_application_vanity_domain=self.auth_config.wristband_application_vanity_domain,
+        )
+
+        result = self.wristband_auth._get_oauth_authorize_url(request, oauth_config)
+
+        assert "idp_hint=google" in result
+
+    def test_get_oauth_authorize_url_multiple_idp_hints_raises_error(self) -> None:
+        """Test _get_oauth_authorize_url raises error when multiple idp_hint params exist."""
+
+        # Create mock with multiple idp_hint values
+        mock_request = create_mock_request("/login")
+        mock_request.query_params.getlist = lambda key: (["google", "facebook"] if key == "idp_hint" else [])
+
+        oauth_config = OAuthAuthorizeUrlConfig(
+            client_id=self.auth_config.client_id,
+            redirect_uri=self.auth_config.redirect_uri or "",
+            code_verifier="test_verifier",
+            scopes=self.auth_config.scopes,
+            state="test_state",
+            tenant_custom_domain="custom.tenant.com",
+            wristband_application_vanity_domain=self.auth_config.wristband_application_vanity_domain,
+        )
+
+        with pytest.raises(TypeError, match="More than one \\[idp_hint\\] query parameter was encountered"):
+            self.wristband_auth._get_oauth_authorize_url(mock_request, oauth_config)
+
 
 class TestWristbandAuthCookieManagement:
     """Test cases for login state cookie management methods."""

--- a/tests/test_config_resolver.py
+++ b/tests/test_config_resolver.py
@@ -675,7 +675,34 @@ class TestConfigResolverDynamicValidation:
                 await resolver.get_redirect_uri()
 
             assert exc_info.value.error == "sdk_config_invalid"
-            assert "missing required field: redirect_uri" in exc_info.value.error_description
+            assert (
+                "The [redirect_uri] could not be resolved. Provide it explicitly in your SDK config "
+                "or ensure your Wristband OAuth2 Client has a single redirect URI configured."
+                in exc_info.value.error_description
+            )
+
+    @pytest.mark.asyncio
+    async def test_manual_redirect_uri_overrides_missing_sdk_redirect_uri(self):
+        """Test that manual redirect_uri succeeds even when SDK config returns empty redirect_uri."""
+        invalid_sdk_config = SdkConfiguration(
+            login_url="https://sdk.example.com/login", redirect_uri="", is_application_custom_domain_active=False
+        )
+
+        config = AuthConfig(
+            client_id="test_client",
+            client_secret="test_secret",
+            wristband_application_vanity_domain="test.wristband.dev",
+            redirect_uri="https://manual.example.com/callback",
+        )
+
+        with patch("wristband.fastapi_auth.config_resolver.WristbandApiClient") as mock_client_class:
+            mock_client = Mock()
+            mock_client.get_sdk_configuration = AsyncMock(return_value=invalid_sdk_config)
+            mock_client_class.return_value = mock_client
+
+            resolver = ConfigResolver(config)
+            result = await resolver.get_redirect_uri()
+            assert result == "https://manual.example.com/callback"
 
     @pytest.mark.asyncio
     async def test_validate_resolved_config_with_tenant_domain(self):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -144,6 +144,20 @@ def test_sdk_configuration_creation_minimal():
     assert config.login_url_tenant_domain_suffix is None
 
 
+def test_sdk_configuration_from_api_response_null_redirect_uri():
+    """Test SdkConfiguration.from_api_response when redirectUri is null (multiple redirect URIs registered)."""
+    api_response = {
+        "loginUrl": "https://auth.example.com/login",
+        "redirectUri": None,
+        "isApplicationCustomDomainActive": False,
+    }
+
+    config = SdkConfiguration.from_api_response(api_response)
+
+    assert config.login_url == "https://auth.example.com/login"
+    assert config.redirect_uri is None
+
+
 def test_sdk_configuration_creation_with_all_fields():
     """Test SdkConfiguration creation with all fields."""
     config = SdkConfiguration(


### PR DESCRIPTION
# Release 2.1.0

## New Features

### ✨ IDP Hint Support
The `login()` flow now forwards the `idp_hint` query parameter to the Wristband Authorize Endpoint when present. This allows applications to bypass the Wristband-hosted Tenant Login Page and send users directly to a specific identity provider.

**Behavior:**
- Matching external IDP — redirects user straight to that IDP's login page (e.g. Google)
- Wristband IDP name — shows only the Wristband login form, no external IDP buttons
- Unrecognized or invalid value — ignored, login page displays as normal

## Bug Fixes

### 🐛 Fix: Explicit `redirectUri` no longer fails when OAuth2 client has multiple redirect URIs
Previously, providing `redirectUri` explicitly in the SDK config would still throw an error during auto-configuration if the Wristband OAuth2 client had multiple redirect URIs configured (causing the endpoint to return `null`). The SDK now correctly uses the manually provided value and skips the null endpoint response.